### PR TITLE
fix: Issue#4 カラーピッカー初期値の同期、Issue#5 animation.js _lFloor=0 ガード

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -71,6 +71,7 @@ export class AnimationController {
     const rangeX = maxX - minX;
     const rangeY = maxY - minY;
     this._lFloor = Math.max(rangeX, rangeY);
+    if (this._lFloor === 0) this._lFloor = 1; // 全節点が同一座標の場合ゼロ除算を回避
     this._aRef = this._lFloor / 10;
   }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -129,6 +129,11 @@ export function setupUI({ viewer, animController, floorData, onFileLoad }) {
   const widthDeformed    = document.getElementById('width-deformed');
   const widthDefVal      = document.getElementById('width-deformed-val');
 
+  // カラーピッカーをビューアーの現在のマテリアル色（テーマ反映済み）に同期
+  const lineColors = viewer.getLineColors();
+  colorUndeformed.value = lineColors.undeformedColor;
+  colorDeformed.value   = lineColors.deformedColor;
+
   const onColorUndeformed = () => {
     viewer.setLineStyle({ undeformedColor: colorUndeformed.value });
   };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -358,6 +358,22 @@ export class FloorViewer {
   }
 
   /**
+   * 現在のマテリアル色を CSS 16進数文字列で返す
+   * テーマ切替・ユーザー指定の両方を反映した実際の描画色
+   * @returns {{ undeformedColor: string, deformedColor: string }}
+   */
+  getLineColors() {
+    const toHex = (mat) => {
+      if (!mat) return '#000000';
+      return '#' + mat.color.getHexString();
+    };
+    return {
+      undeformedColor: toHex(this._undeformedMaterial),
+      deformedColor:   toHex(this._deformedMaterial),
+    };
+  }
+
+  /**
    * 線の色・太さをユーザー指定値で更新する
    * @param {object} style
    * @param {string|number|null} [style.undeformedColor] - CSS色文字列 or 0xRRGGBB


### PR DESCRIPTION
## 対応 Issue

- closes #4
- closes #5

## 修正内容

### Issue #4 — ダークモード起動時にカラーピッカーの初期値と実際の描画色が不一致

**原因**: `index.html` に直書きされたカラーピッカーの `value` 属性がライトテーマ固定値のため、ダークモード復元後に `setupUI()` が呼ばれても色が同期されていなかった。

**修正**:
- `src/viewer.js`: `getLineColors()` メソッドを追加。現在のマテリアル色（ユーザー指定またはテーマデフォルト）を `{ undeformedColor: '#xxxxxx', deformedColor: '#xxxxxx' }` として返す。
- `src/ui.js`: `setupUI()` 内でカラーピッカー初期化直後に `viewer.getLineColors()` を呼び出し、`value` を同期するコードを追加。

### Issue #5 — animation.js: 節点が同一座標の場合に `_aRef=0` でアニメーションが無音で停止する

**原因**: `viewer.js` には `if (this._lFloor === 0) this._lFloor = 1;` のゼロ除算ガードが実装済みだが、`animation.js` の `_computeFloorMetrics()` には未実装だった。

**修正**:
- `src/animation.js`: `_computeFloorMetrics()` に `if (this._lFloor === 0) this._lFloor = 1;` を追加。

## 変更ファイル

| ファイル | 変更概要 |
|---|---|
| `src/viewer.js` | `getLineColors()` メソッドを追加 |
| `src/ui.js` | カラーピッカー初期値をマテリアル現在色に同期 |
| `src/animation.js` | `_lFloor === 0` 時のゼロ除算ガードを追加 |
