### PR TITLE
refactor: 共通定数・座標計算の集約とUI分割、潜在バグ修正

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -8,7 +8,8 @@
  *   z_i'(t) = z_i + u_i(t)
  */
 
-const TWO_PI = 2 * Math.PI;
+import { TWO_PI, SCALE, SPEED } from './constants.js';
+import { computeFloorMetrics } from './geometry.js';
 
 export class AnimationController {
   /**
@@ -22,7 +23,9 @@ export class AnimationController {
     this._modes = floorData.modes;       // Map<modeNum, Map<nodeId, uz>>
 
     // L_floor と A_ref を算出
-    this._computeFloorMetrics();
+    const metrics = computeFloorMetrics(this._nodes);
+    this._lFloor = metrics.lFloor;
+    this._aRef = metrics.aRef;
 
     // Umax_m をモードごとに事前計算
     this._umaxMap = new Map(); // Map<modeNum, number>
@@ -40,8 +43,8 @@ export class AnimationController {
 
     // 状態初期化
     this._currentMode = null;
-    this._scale = 1.0;     // S: 変形倍率
-    this._speed = 1.0;     // 再生速度倍率 (0.2〜2.0)
+    this._scale = SCALE.DEFAULT;     // S: 変形倍率
+    this._speed = SPEED.DEFAULT;     // 再生速度倍率
     this._time = 0;        // t [s]
     this._playing = false;
 
@@ -52,27 +55,6 @@ export class AnimationController {
     if (this._modeList.length > 0) {
       this._currentMode = this._modeList[0];
     }
-  }
-
-  /**
-   * 節点座標から L_floor, A_ref を計算
-   */
-  _computeFloorMetrics() {
-    let minX = Infinity, maxX = -Infinity;
-    let minY = Infinity, maxY = -Infinity;
-
-    for (const node of this._nodes.values()) {
-      if (node.x < minX) minX = node.x;
-      if (node.x > maxX) maxX = node.x;
-      if (node.y < minY) minY = node.y;
-      if (node.y > maxY) maxY = node.y;
-    }
-
-    const rangeX = maxX - minX;
-    const rangeY = maxY - minY;
-    this._lFloor = Math.max(rangeX, rangeY);
-    if (this._lFloor === 0) this._lFloor = 1; // 全節点が同一座標の場合ゼロ除算を回避
-    this._aRef = this._lFloor / 10;
   }
 
   /**
@@ -102,11 +84,11 @@ export class AnimationController {
   }
 
   /**
-   * 倍率 S 設定 (0.5〜3.0 をクランプ)
+   * 倍率 S 設定 (SCALE.MIN〜SCALE.MAX をクランプ)
    * @param {number} s
    */
   setScale(s) {
-    this._scale = Math.max(0.5, Math.min(3.0, s));
+    this._scale = Math.max(SCALE.MIN, Math.min(SCALE.MAX, s));
   }
 
   /**
@@ -150,7 +132,7 @@ export class AnimationController {
     // 未記載の節点モード値は uz = 0.0 とみなす
     const uz_im = modeShape.has(nodeId) ? modeShape.get(nodeId) : 0.0;
     const umaxM = this._umaxMap.get(this._currentMode);
-    const freqM = this._freqHz.get(this._currentMode) || 0;
+    const freqM = this._freqHz.get(this._currentMode) ?? 0;
 
     // u_i(t) = S * A_ref * (uz_i,m / Umax_m) * sin(2π f_m t)
     const u_i = this._scale * this._aRef * (uz_im / umaxM) * Math.sin(TWO_PI * freqM * this._time);
@@ -159,11 +141,11 @@ export class AnimationController {
   }
 
   /**
-   * 再生速度倍率を設定 (0.2〜2.0 をクランプ)
+   * 再生速度倍率を設定 (SPEED.MIN〜SPEED.MAX をクランプ)
    * @param {number} speed
    */
   setSpeed(speed) {
-    this._speed = Math.max(0.2, Math.min(2.0, speed));
+    this._speed = Math.max(SPEED.MIN, Math.min(SPEED.MAX, speed));
   }
 
   /**
@@ -193,7 +175,7 @@ export class AnimationController {
     if (modeNum === undefined || modeNum === null) {
       modeNum = this._currentMode;
     }
-    return this._freqHz.get(modeNum) || 0;
+    return this._freqHz.get(modeNum) ?? 0;
   }
 
   /**

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ import { FloorViewer } from './viewer.js';
 import { AnimationController } from './animation.js';
 import { setupUI, updateTimeDisplay } from './ui.js';
 import { initLang, t, applyTranslations } from './i18n.js';
+import { DOM_IDS, STORAGE_KEYS } from './constants.js';
 
 /** @type {FloorViewer|null} */
 let viewer = null;
@@ -29,29 +30,27 @@ let rafId = 0;
  * @param {Array<{code:string,message:string}>} warnings
  */
 function showMessages(errors, warnings) {
-  const container = document.getElementById('error-container');
+  const container = document.getElementById(DOM_IDS.errorContainer);
+  if (!container) return;
   container.innerHTML = '';
 
-  for (const w of warnings) {
+  const append = (cls, message) => {
     const div = document.createElement('div');
-    div.className = 'msg-warning';
-    div.textContent = w.message;
+    div.className = cls;
+    div.textContent = message;
     container.appendChild(div);
-  }
+  };
 
-  for (const e of errors) {
-    const div = document.createElement('div');
-    div.className = 'msg-error';
-    div.textContent = e.message;
-    container.appendChild(div);
-  }
+  warnings.forEach((w) => append('msg-warning', w.message));
+  errors.forEach((e) => append('msg-error', e.message));
 }
 
 /**
  * #error-container をクリアする。
  */
 function clearMessages() {
-  document.getElementById('error-container').innerHTML = '';
+  const container = document.getElementById(DOM_IDS.errorContainer);
+  if (container) container.innerHTML = '';
 }
 
 /**
@@ -87,10 +86,7 @@ function loadData(jsonText) {
   }
 
   // 既存アニメーションループを停止
-  if (rafId) {
-    cancelAnimationFrame(rafId);
-    rafId = 0;
-  }
+  stopAnimationLoop();
 
   // シーン構築
   viewer.loadFloorData(data);
@@ -111,10 +107,28 @@ function loadData(jsonText) {
   viewer.render();
 
   // アニメーションループ開始
-  prevTimestamp = 0;
-  rafId = requestAnimationFrame(animationLoop);
+  startAnimationLoop();
 
   return true;
+}
+
+/**
+ * アニメーションループを開始する（既存ループがあれば張り替える）。
+ */
+function startAnimationLoop() {
+  stopAnimationLoop();
+  prevTimestamp = 0;
+  rafId = requestAnimationFrame(animationLoop);
+}
+
+/**
+ * 実行中のアニメーションループを停止する。
+ */
+function stopAnimationLoop() {
+  if (rafId) {
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
 }
 
 /**
@@ -163,7 +177,7 @@ export async function initApp() {
   initLang();
   applyTranslations();
 
-  const canvasContainer = document.getElementById('canvas-container');
+  const canvasContainer = document.getElementById(DOM_IDS.canvasContainer);
 
   // FloorViewer 初期化
   try {
@@ -181,7 +195,7 @@ export async function initApp() {
   viewer.resize();
 
   // 保存済みテーマの復元
-  const savedTheme = localStorage.getItem('floor-mode-theme');
+  const savedTheme = localStorage.getItem(STORAGE_KEYS.theme);
   if (savedTheme === 'dark') {
     document.documentElement.setAttribute('data-theme', 'dark');
     viewer.setThemeColors(true);
@@ -193,19 +207,23 @@ export async function initApp() {
   });
 
   // サンプル JSON 自動読込
+  let loaded = false;
   try {
     const res = await fetch('Sample/sample_case.json');
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const jsonText = await res.text();
-    loadData(jsonText);
+    loaded = loadData(jsonText);
   } catch (err) {
     console.error('Sample data load failed:', err);
     showMessages(
       [{ code: 'E_FETCH', message: t('errorFetch', { msg: err.message }) }],
       [],
     );
-    // サンプル読込失敗でも viewer は動かしておく
-    prevTimestamp = 0;
-    rafId = requestAnimationFrame(animationLoop);
+  }
+
+  // サンプル読込失敗・バリデーションエラー時でも viewer は動かしておく
+  // （loadData 成功時は内部でループ開始済み）
+  if (!loaded) {
+    startAnimationLoop();
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,100 @@
+/**
+ * constants.js -- プロジェクト共通の定数を集約する。
+ *
+ * 色・寸法・範囲などのマジックナンバーや、複数モジュールで共有する
+ * 値を一箇所に集約し、片側のみ変更による不整合を防ぐ。
+ *
+ * @module constants
+ */
+
+/** 浮動小数比較用イプシロン（CLAUDE.md 規約） */
+export const EPS = 1e-9;
+
+/** 2π（角速度計算用） */
+export const TWO_PI = 2 * Math.PI;
+
+/** A_ref = L_floor / A_REF_DIVISOR */
+export const A_REF_DIVISOR = 10;
+
+/** localStorage キー */
+export const STORAGE_KEYS = {
+  theme: 'floor-mode-theme',
+  lang: 'floor-mode-lang',
+};
+
+/** 変形倍率 S の範囲（スライダー・クランプ共通） */
+export const SCALE = { MIN: 0.5, MAX: 3.0, DEFAULT: 1.0 };
+
+/** 再生速度倍率の範囲（スライダー・クランプ共通） */
+export const SPEED = { MIN: 0.2, MAX: 2.0, DEFAULT: 1.0 };
+
+/** 線スタイル既定値 */
+export const LINE_WIDTH = { undeformed: 2, deformed: 3 };
+
+/**
+ * テーマ別の色（ライト / ダーク）。
+ * loadFloorData / setThemeColors の双方がこれを参照し、色定義の単一ソースとする。
+ */
+export const THEME = {
+  light: {
+    clear: 0xffffff,
+    undeformed: 0x888888,
+    deformed: 0xff4444,
+    grid: 0xcccccc,
+  },
+  dark: {
+    clear: 0x1a1a2e,
+    undeformed: 0xaaaaaa,
+    deformed: 0xff6666,
+    grid: 0x444466,
+  },
+};
+
+/** 3D ビュー（カメラ・グリッド・軸）の調整係数 */
+export const VIEW = {
+  CAMERA_FOV: 50,
+  CAMERA_NEAR: 0.1,
+  CAMERA_FAR: 10000,
+  /** カメラ距離 = L_floor * CAMERA_DIST_FACTOR */
+  CAMERA_DIST_FACTOR: 1.5,
+  /** カメラ位置オフセット係数（dist 倍率） */
+  CAMERA_OFFSET: { x: -0.85, y: 0.7, z: 0.4 },
+  /** 軸サイズ = L_floor * AXES_SIZE_FACTOR */
+  AXES_SIZE_FACTOR: 0.5,
+  /** グリッドサイズ = L_floor * GRID_SIZE_FACTOR */
+  GRID_SIZE_FACTOR: 1.5,
+  GRID_DIVISIONS: 10,
+};
+
+/** DOM 要素 ID（タイポ防止のため集約） */
+export const DOM_IDS = {
+  canvasContainer: 'canvas-container',
+  modeSelect: 'mode-select',
+  freqDisplay: 'freq-display',
+  timeDisplay: 'time-display',
+  btnPlay: 'btn-play',
+  btnStop: 'btn-stop',
+  speedSlider: 'speed-slider',
+  speedValue: 'speed-value',
+  scaleSlider: 'scale-slider',
+  scaleValue: 'scale-value',
+  chkUndeformed: 'chk-undeformed',
+  chkDeformed: 'chk-deformed',
+  chkAxes: 'chk-axes',
+  chkGrid: 'chk-grid',
+  chkNodeIds: 'chk-node-ids',
+  colorUndeformed: 'color-undeformed',
+  widthUndeformed: 'width-undeformed',
+  widthUndeformedVal: 'width-undeformed-val',
+  colorDeformed: 'color-deformed',
+  widthDeformed: 'width-deformed',
+  widthDeformedVal: 'width-deformed-val',
+  btnTheme: 'btn-theme',
+  btnLang: 'btn-lang',
+  btnDownload: 'btn-download',
+  fileInput: 'file-input',
+  btnSelectFile: 'btn-select-file',
+  fileNameDisplay: 'file-name-display',
+  helpContent: 'help-content',
+  errorContainer: 'error-container',
+};

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -1,0 +1,83 @@
+/**
+ * geometry.js -- 座標計算ユーティリティ
+ *
+ * 節点バウンディングボックスからの L_floor / A_ref 算出と、
+ * データ座標系 → three.js 座標系のマッピングを一元管理する。
+ * これらは従来 animation.js と viewer.js に重複していた。
+ *
+ * 座標系（CLAUDE.md, 右手系）:
+ *   data.y → three.x（Node1→4方向）
+ *   data.z → three.y（鉛直上向き）
+ *   data.x → three.z（Node1→2方向）
+ *
+ * @module geometry
+ */
+
+import { A_REF_DIVISOR } from './constants.js';
+
+/**
+ * 節点群のバウンディングボックス・中心・L_floor・A_ref を計算する。
+ *
+ * L_floor = max(maxX - minX, maxY - minY)（CLAUDE.md 規約）
+ * A_ref   = L_floor / A_REF_DIVISOR
+ * 全節点が同一座標で L_floor=0 のときはゼロ除算回避のため 1 とする。
+ *
+ * @param {Map<number,{x:number,y:number,z:number}>} nodes
+ * @returns {{
+ *   minX:number, maxX:number, minY:number, maxY:number, minZ:number, maxZ:number,
+ *   centerX:number, centerY:number, centerZ:number,
+ *   lFloor:number, aRef:number
+ * }}
+ */
+export function computeFloorMetrics(nodes) {
+  let minX = Infinity, maxX = -Infinity;
+  let minY = Infinity, maxY = -Infinity;
+  let minZ = Infinity, maxZ = -Infinity;
+
+  for (const node of nodes.values()) {
+    if (node.x < minX) minX = node.x;
+    if (node.x > maxX) maxX = node.x;
+    if (node.y < minY) minY = node.y;
+    if (node.y > maxY) maxY = node.y;
+    if (node.z < minZ) minZ = node.z;
+    if (node.z > maxZ) maxZ = node.z;
+  }
+
+  const rangeX = maxX - minX;
+  const rangeY = maxY - minY;
+  let lFloor = Math.max(rangeX, rangeY);
+  if (lFloor === 0) lFloor = 1; // 全節点が同一座標の場合ゼロ除算を回避
+
+  return {
+    minX, maxX, minY, maxY, minZ, maxZ,
+    centerX: (minX + maxX) / 2,
+    centerY: (minY + maxY) / 2,
+    centerZ: (minZ + maxZ) / 2,
+    lFloor,
+    aRef: lFloor / A_REF_DIVISOR,
+  };
+}
+
+/**
+ * データ座標 (x, y, z) を three.js 座標配列 [x', y', z'] に変換する。
+ * data.y → three.x, data.z → three.y, data.x → three.z
+ *
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @returns {[number, number, number]}
+ */
+export function toThree(x, y, z) {
+  return [y, z, x];
+}
+
+/**
+ * three.js オブジェクトの position をデータ座標から設定する。
+ * @param {{position:{set:(x:number,y:number,z:number)=>void}}} obj
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ */
+export function setThreePosition(obj, x, y, z) {
+  obj.position.set(y, z, x);
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,7 +2,9 @@
    i18n.js -- 多言語対応モジュール (ja / en)
    ======================================================================== */
 
-const STORAGE_KEY = 'floor-mode-lang';
+import { STORAGE_KEYS } from './constants.js';
+
+const STORAGE_KEY = STORAGE_KEYS.lang;
 
 const dict = {
   ja: {
@@ -118,8 +120,9 @@ export function t(key, params) {
     return key; // キーそのものを返す
   }
   if (params) {
+    // replaceAll でリテラル置換（置換値の $ などの特殊パターン展開を回避）
     for (const [k, v] of Object.entries(params)) {
-      str = str.replace(new RegExp('\\{' + k + '\\}', 'g'), v);
+      str = str.replaceAll('{' + k + '}', String(v));
     }
   }
   return str;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,205 +1,190 @@
 /**
  * ui.js -- UIコントロール・イベント管理
  *
+ * setupUI を責務ごとのセクション関数へ分割し、各セクションは
+ * DOM_IDS と共通ヘルパー（replaceListener / wireSlider）を介して配線する。
+ *
  * @module ui
  */
 
 import { t, setLang, getLang, applyTranslations } from './i18n.js';
+import { DOM_IDS, SCALE, SPEED, STORAGE_KEYS } from './constants.js';
+
+/** getElementById の短縮 */
+const $ = (id) => document.getElementById(id);
 
 /**
  * UI 要素のイベントリスナーを設定する。
  *
  * @param {object}              params
- * @param {import('./viewer.js').FloorViewer}         params.viewer
- * @param {import('./animation.js').AnimationController} params.animController
+ * @param {import('./viewer.js').FloorViewer}            params.viewer
+ * @param {import('./animation.js').AnimationController}  params.animController
  * @param {object}              params.floorData        parseFloorData の戻り値
  * @param {(jsonString:string)=>void} params.onFileLoad  ファイル読込コールバック
  */
 export function setupUI({ viewer, animController, floorData, onFileLoad }) {
-  // ---------- モード選択 ----------
-  const modeSelect = document.getElementById('mode-select');
-  // 既存の option をクリア
-  modeSelect.innerHTML = '';
+  // 表示切替は複数セクション（再生/停止・モード変更）から参照されるため先に定義する
+  const applyVisibility = () => {
+    viewer.setVisibility({
+      undeformed: $(DOM_IDS.chkUndeformed).checked,
+      deformed:   $(DOM_IDS.chkDeformed).checked,
+      axes:       $(DOM_IDS.chkAxes).checked,
+      grid:       $(DOM_IDS.chkGrid).checked,
+      labels:     $(DOM_IDS.chkNodeIds).checked && !animController.isPlaying(),
+    });
+  };
 
-  // animController から利用可能なモード番号一覧を取得
-  const modeList = animController.getModeList();
-  for (const modeNum of modeList) {
-    const opt = document.createElement('option');
-    opt.value = String(modeNum);
-    const freq = animController.getFreqHz(modeNum);
-    opt.textContent = t('modeOption', { n: modeNum, f: freq.toFixed(2) });
-    modeSelect.appendChild(opt);
-  }
+  setupModeControls(animController, applyVisibility);
+  setupPlaybackControls(animController, applyVisibility);
+  setupSliders(animController);
+  setupVisibilityControls(applyVisibility);
+  setupLineStyleControls(viewer);
+  setupThemeControl(viewer);
+  setupLangControl(animController);
+  setupPngControl(viewer, animController, floorData);
+  setupFileLoad(onFileLoad);
+
+  // 時間表示・ヘルプ内容を初期化
+  updateTimeDisplay(animController.getTime());
+  const helpContent = $(DOM_IDS.helpContent);
+  if (helpContent) helpContent.textContent = t('helpContent');
+}
+
+// ─── セクション ─────────────────────────────────────────────────────────────
+
+/** モード選択ドロップダウンと振動数表示 */
+function setupModeControls(animController, applyVisibility) {
+  const modeSelect = $(DOM_IDS.modeSelect);
+  rebuildModeOptions(modeSelect, animController);
 
   // 先頭モードを選択状態にしておく
+  const modeList = animController.getModeList();
   if (modeList.length > 0) {
     modeSelect.value = String(modeList[0]);
   }
 
-  // 振動数表示を初期化
   updateFreqDisplay(animController);
 
-  // change イベント — 新しいリスナーだけ残す
   const onModeChange = () => {
-    const n = Number(modeSelect.value);
-    animController.setMode(n);
+    animController.setMode(Number(modeSelect.value));
     updateFreqDisplay(animController);
     updateTimeDisplay(animController.getTime());
+    // setMode で停止状態になるため、ラベル表示などを再評価する
+    applyVisibility();
   };
   replaceListener(modeSelect, 'change', onModeChange, '_onModeChange');
+}
 
-  // ---------- 再生 / 停止ボタン ----------
-  const btnPlay = document.getElementById('btn-play');
-  const btnStop = document.getElementById('btn-stop');
+/** 再生 / 停止ボタン */
+function setupPlaybackControls(animController, applyVisibility) {
+  const btnPlay = $(DOM_IDS.btnPlay);
+  const btnStop = $(DOM_IDS.btnStop);
 
   const onPlay = () => { animController.play(); applyVisibility(); };
   const onStop = () => { animController.stop(); applyVisibility(); };
   replaceListener(btnPlay, 'click', onPlay, '_onPlay');
   replaceListener(btnStop, 'click', onStop, '_onStop');
+}
 
-  // ---------- 速度スライダー ----------
-  const speedSlider = document.getElementById('speed-slider');
-  const speedValue  = document.getElementById('speed-value');
+/** 速度・変形倍率スライダー */
+function setupSliders(animController) {
+  const speedSlider = $(DOM_IDS.speedSlider);
+  const speedValue  = $(DOM_IDS.speedValue);
+  speedSlider.value = String(SPEED.DEFAULT);
+  speedValue.textContent = SPEED.DEFAULT.toFixed(1);
+  animController.setSpeed(SPEED.DEFAULT);
+  wireSlider(speedSlider, speedValue, (v) => animController.setSpeed(v), '_onSpeedInput');
 
-  speedSlider.value = '1.0';
-  speedValue.textContent = '1.0';
-  animController.setSpeed(1.0);
+  const scaleSlider = $(DOM_IDS.scaleSlider);
+  const scaleValue  = $(DOM_IDS.scaleValue);
+  scaleSlider.value = String(SCALE.DEFAULT);
+  scaleValue.textContent = SCALE.DEFAULT.toFixed(1);
+  animController.setScale(SCALE.DEFAULT);
+  wireSlider(scaleSlider, scaleValue, (v) => animController.setScale(v), '_onScaleInput');
+}
 
-  const onSpeedInput = () => {
-    const sp = parseFloat(speedSlider.value);
-    animController.setSpeed(sp);
-    speedValue.textContent = sp.toFixed(1);
-  };
-  replaceListener(speedSlider, 'input', onSpeedInput, '_onSpeedInput');
-
-  // ---------- 変形倍率スライダー ----------
-  const scaleSlider = document.getElementById('scale-slider');
-  const scaleValue  = document.getElementById('scale-value');
-
-  scaleSlider.value = '1.0';
-  scaleValue.textContent = '1.0';
-  animController.setScale(1.0);
-
-  const onScaleInput = () => {
-    const s = parseFloat(scaleSlider.value);
-    animController.setScale(s);
-    scaleValue.textContent = s.toFixed(1);
-  };
-  replaceListener(scaleSlider, 'input', onScaleInput, '_onScaleInput');
-
-  // ---------- 表示切替チェックボックス ----------
-  const chkUndeformed = document.getElementById('chk-undeformed');
-  const chkDeformed   = document.getElementById('chk-deformed');
-  const chkAxes       = document.getElementById('chk-axes');
-  const chkGrid       = document.getElementById('chk-grid');
-  const chkNodeIds    = document.getElementById('chk-node-ids');
+/** 表示切替チェックボックス */
+function setupVisibilityControls(applyVisibility) {
+  const checks = [
+    DOM_IDS.chkUndeformed, DOM_IDS.chkDeformed, DOM_IDS.chkAxes,
+    DOM_IDS.chkGrid, DOM_IDS.chkNodeIds,
+  ].map($);
 
   // 初期状態を全て checked に戻す
-  chkUndeformed.checked = true;
-  chkDeformed.checked   = true;
-  chkAxes.checked       = true;
-  chkGrid.checked       = true;
-  chkNodeIds.checked    = true;
-
-  const applyVisibility = () => {
-    viewer.setVisibility({
-      undeformed: chkUndeformed.checked,
-      deformed:   chkDeformed.checked,
-      axes:       chkAxes.checked,
-      grid:       chkGrid.checked,
-      labels:     chkNodeIds.checked && !animController.isPlaying(),
-    });
-  };
+  checks.forEach((chk) => { chk.checked = true; });
 
   // 初回適用
   applyVisibility();
 
-  const onVisChange = () => { applyVisibility(); };
-  replaceListener(chkUndeformed, 'change', onVisChange, '_onVis');
-  replaceListener(chkDeformed,   'change', onVisChange, '_onVis');
-  replaceListener(chkAxes,       'change', onVisChange, '_onVis');
-  replaceListener(chkGrid,       'change', onVisChange, '_onVis');
-  replaceListener(chkNodeIds,    'change', onVisChange, '_onVis');
+  const onVisChange = () => applyVisibility();
+  checks.forEach((chk, i) => replaceListener(chk, 'change', onVisChange, `_onVis${i}`));
+}
 
-  // ---------- 線の設定（色・太さ） ----------
-  const colorUndeformed  = document.getElementById('color-undeformed');
-  const widthUndeformed  = document.getElementById('width-undeformed');
-  const widthUndefVal    = document.getElementById('width-undeformed-val');
-  const colorDeformed    = document.getElementById('color-deformed');
-  const widthDeformed    = document.getElementById('width-deformed');
-  const widthDefVal      = document.getElementById('width-deformed-val');
+/** 線の色・太さ設定 */
+function setupLineStyleControls(viewer) {
+  const colorUndeformed = $(DOM_IDS.colorUndeformed);
+  const widthUndeformed = $(DOM_IDS.widthUndeformed);
+  const widthUndefVal   = $(DOM_IDS.widthUndeformedVal);
+  const colorDeformed   = $(DOM_IDS.colorDeformed);
+  const widthDeformed   = $(DOM_IDS.widthDeformed);
+  const widthDefVal     = $(DOM_IDS.widthDeformedVal);
 
   // カラーピッカーをビューアーの現在のマテリアル色（テーマ反映済み）に同期
   const lineColors = viewer.getLineColors();
   colorUndeformed.value = lineColors.undeformedColor;
   colorDeformed.value   = lineColors.deformedColor;
 
-  const onColorUndeformed = () => {
-    viewer.setLineStyle({ undeformedColor: colorUndeformed.value });
-  };
-  const onWidthUndeformed = () => {
-    const w = parseFloat(widthUndeformed.value);
-    widthUndefVal.textContent = w.toFixed(1);
-    viewer.setLineStyle({ undeformedWidth: w });
-  };
-  const onColorDeformed = () => {
-    viewer.setLineStyle({ deformedColor: colorDeformed.value });
-  };
-  const onWidthDeformed = () => {
-    const w = parseFloat(widthDeformed.value);
-    widthDefVal.textContent = w.toFixed(1);
-    viewer.setLineStyle({ deformedWidth: w });
-  };
-
+  const onColorUndeformed = () => viewer.setLineStyle({ undeformedColor: colorUndeformed.value });
+  const onColorDeformed   = () => viewer.setLineStyle({ deformedColor: colorDeformed.value });
   replaceListener(colorUndeformed, 'input', onColorUndeformed, '_onColorUndef');
-  replaceListener(widthUndeformed, 'input', onWidthUndeformed, '_onWidthUndef');
   replaceListener(colorDeformed,   'input', onColorDeformed,   '_onColorDef');
-  replaceListener(widthDeformed,   'input', onWidthDeformed,   '_onWidthDef');
 
-  // ---------- テーマ切替 ----------
-  const btnTheme = document.getElementById('btn-theme');
+  wireSlider(widthUndeformed, widthUndefVal, (w) => viewer.setLineStyle({ undeformedWidth: w }), '_onWidthUndef');
+  wireSlider(widthDeformed,   widthDefVal,   (w) => viewer.setLineStyle({ deformedWidth: w }),   '_onWidthDef');
+}
+
+/** テーマ切替ボタン */
+function setupThemeControl(viewer) {
+  const btnTheme = $(DOM_IDS.btnTheme);
   const onThemeToggle = () => {
     const html = document.documentElement;
     const isDark = html.getAttribute('data-theme') !== 'dark';
     html.setAttribute('data-theme', isDark ? 'dark' : '');
     viewer.setThemeColors(isDark);
-    btnTheme.textContent = t(isDark ? 'btnThemeDark' : 'btnThemeLight');
-    localStorage.setItem('floor-mode-theme', isDark ? 'dark' : 'light');
+    updateThemeButtonLabel();
+    localStorage.setItem(STORAGE_KEYS.theme, isDark ? 'dark' : 'light');
   };
   replaceListener(btnTheme, 'click', onThemeToggle, '_onThemeToggle');
+}
 
-  // ---------- 言語切替 ----------
-  const btnLang = document.getElementById('btn-lang');
+/** 言語切替ボタン */
+function setupLangControl(animController) {
+  const btnLang = $(DOM_IDS.btnLang);
   const onLangToggle = () => {
-    const newLang = getLang() === 'ja' ? 'en' : 'ja';
-    setLang(newLang);
+    setLang(getLang() === 'ja' ? 'en' : 'ja');
     applyTranslations();
     btnLang.textContent = t('btnLang');
-    // テーマボタンのテキストも更新
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    btnTheme.textContent = t(isDark ? 'btnThemeDark' : 'btnThemeLight');
-    // モード選択を再構築
-    rebuildModeOptions(modeSelect, animController);
-    // 時間表示更新
+    updateThemeButtonLabel();
+    // モード選択を再構築 / 各表示を更新
+    rebuildModeOptions($(DOM_IDS.modeSelect), animController);
     updateTimeDisplay(animController.getTime());
-    // ヘルプ内容更新
-    const helpContent = document.getElementById('help-content');
+    const helpContent = $(DOM_IDS.helpContent);
     if (helpContent) helpContent.textContent = t('helpContent');
     // ファイル名表示更新（ファイル未選択時のみ）
-    const fnd = document.getElementById('file-name-display');
+    const fnd = $(DOM_IDS.fileNameDisplay);
     if (fnd && !fnd._hasFile) fnd.textContent = t('fileNameNone');
   };
   replaceListener(btnLang, 'click', onLangToggle, '_onLangToggle');
+}
 
-  // ---------- PNG 保存ボタン ----------
-  const btnDownload = document.getElementById('btn-download');
-
+/** PNG 保存ボタン */
+function setupPngControl(viewer, animController, floorData) {
+  const btnDownload = $(DOM_IDS.btnDownload);
   const onDownload = async () => {
     if (animController.isPlaying()) {
       alert(t('alertPngStop'));
       return;
     }
-
     const filename = buildPngFilename(floorData, animController);
     try {
       await viewer.savePNG(filename);
@@ -209,17 +194,17 @@ export function setupUI({ viewer, animController, floorData, onFileLoad }) {
     }
   };
   replaceListener(btnDownload, 'click', onDownload, '_onDownload');
+}
 
-  // ---------- ファイル読込 ----------
-  const fileInput = document.getElementById('file-input');
-  const btnSelectFile = document.getElementById('btn-select-file');
-  const fileNameDisplay = document.getElementById('file-name-display');
+/** ファイル読込（hidden input + カスタムボタン） */
+function setupFileLoad(onFileLoad) {
+  const fileInput = $(DOM_IDS.fileInput);
+  const btnSelectFile = $(DOM_IDS.btnSelectFile);
+  const fileNameDisplay = $(DOM_IDS.fileNameDisplay);
 
-  // ファイル名表示を初期化
   fileNameDisplay.textContent = t('fileNameNone');
   fileNameDisplay._hasFile = false;
 
-  // カスタムボタンでhidden inputをトリガー
   const onSelectFile = () => { fileInput.click(); };
   replaceListener(btnSelectFile, 'click', onSelectFile, '_onSelectFile');
 
@@ -227,39 +212,28 @@ export function setupUI({ viewer, animController, floorData, onFileLoad }) {
     const file = e.target.files[0];
     if (!file) return;
 
-    // ファイル名を表示
     fileNameDisplay.textContent = file.name;
     fileNameDisplay._hasFile = true;
 
     const reader = new FileReader();
-    reader.onload = () => {
-      onFileLoad(reader.result);
-    };
-    reader.onerror = () => {
-      alert(t('alertFileError', { msg: reader.error.message }));
-    };
+    reader.onload = () => { onFileLoad(reader.result); };
+    reader.onerror = () => { alert(t('alertFileError', { msg: reader.error.message })); };
     reader.readAsText(file);
 
     // 同じファイルを再選択できるようにリセット
     fileInput.value = '';
   };
   replaceListener(fileInput, 'change', onFileChange, '_onFileChange');
-
-  // ---------- 時間表示を初期状態に ----------
-  updateTimeDisplay(animController.getTime());
-
-  // ヘルプ内容設定
-  const helpContent = document.getElementById('help-content');
-  if (helpContent) helpContent.textContent = t('helpContent');
 }
+
+// ─── 表示更新 ───────────────────────────────────────────────────────────────
 
 /**
  * 時間表示を更新する。
- *
  * @param {number} time  現在時刻 [s]
  */
 export function updateTimeDisplay(time) {
-  const el = document.getElementById('time-display');
+  const el = $(DOM_IDS.timeDisplay);
   if (el) {
     el.textContent = t('timeDisplay', { t: time.toFixed(3) });
   }
@@ -267,19 +241,26 @@ export function updateTimeDisplay(time) {
 
 /**
  * 振動数表示を更新する。
- *
  * @param {import('./animation.js').AnimationController} animController
  */
 function updateFreqDisplay(animController) {
-  const el = document.getElementById('freq-display');
+  const el = $(DOM_IDS.freqDisplay);
   if (el) {
-    const freq = animController.getFreqHz();
-    el.textContent = t('freqDisplay', { f: freq.toFixed(2) });
+    el.textContent = t('freqDisplay', { f: animController.getFreqHz().toFixed(2) });
   }
+}
+
+/** テーマボタンのラベルを現在のテーマに合わせて更新する。 */
+function updateThemeButtonLabel() {
+  const btnTheme = $(DOM_IDS.btnTheme);
+  if (!btnTheme) return;
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  btnTheme.textContent = t(isDark ? 'btnThemeDark' : 'btnThemeLight');
 }
 
 // ─── ヘルパー ───────────────────────────────────────────────────────────────
 
+/** モード選択 option を現在の言語・モード一覧で再構築する（選択値は保持）。 */
 function rebuildModeOptions(selectEl, animCtrl) {
   const currentValue = selectEl.value;
   selectEl.innerHTML = '';
@@ -291,6 +272,25 @@ function rebuildModeOptions(selectEl, animCtrl) {
     selectEl.appendChild(opt);
   }
   selectEl.value = currentValue;
+}
+
+/**
+ * range スライダーの input を配線する共通ヘルパー。
+ * 値を valEl に小数表示し、apply(値) を呼ぶ。
+ *
+ * @param {HTMLInputElement} slider
+ * @param {HTMLElement}      valEl
+ * @param {(value:number)=>void} apply
+ * @param {string}           slot    要素に保存するハンドラ slot 名
+ * @param {number}           [digits=1]
+ */
+function wireSlider(slider, valEl, apply, slot, digits = 1) {
+  const handler = () => {
+    const v = parseFloat(slider.value);
+    valEl.textContent = v.toFixed(digits);
+    apply(v);
+  };
+  replaceListener(slider, 'input', handler, slot);
 }
 
 /**
@@ -331,17 +331,15 @@ function buildPngFilename(floorData, animController) {
   // 現在のモード番号 — getModeList の先頭をフォールバックに使う
   const modeList = animController.getModeList();
   let currentMode = modeList.length > 0 ? modeList[0] : 1;
-  const modeSelect = document.getElementById('mode-select');
+  const modeSelect = $(DOM_IDS.modeSelect);
   if (modeSelect && modeSelect.value) {
     currentMode = Number(modeSelect.value);
   }
 
-  // 時刻
   const sec3 = animController.getTime().toFixed(3);
 
-  // スケール
-  const scaleSlider = document.getElementById('scale-slider');
-  const scale = scaleSlider ? parseFloat(scaleSlider.value).toFixed(1) : '1.0';
+  const scaleSlider = $(DOM_IDS.scaleSlider);
+  const scale = scaleSlider ? parseFloat(scaleSlider.value).toFixed(1) : SCALE.DEFAULT.toFixed(1);
 
   return `floormode_${title}_mode${currentMode}_t${sec3}_x${scale}.png`;
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -4,11 +4,20 @@
  * @module validator
  */
 
-/** 浮動小数比較用イプシロン */
-const EPS = 1e-9;
+import { EPS } from './constants.js';
 
 /** 収集するエラーの上限 */
 const MAX_ERRORS = 100;
+
+/**
+ * `E_XXX_YYY: 説明` 形式のメッセージ項目を生成する（CLAUDE.md 規約）。
+ * @param {string} code
+ * @param {string} message
+ * @returns {{code:string, message:string}}
+ */
+function formatItem(code, message) {
+  return { code, message: `${code}: ${message}` };
+}
 
 /**
  * エラーを収集配列に追加する（上限チェック付き）。
@@ -19,7 +28,7 @@ const MAX_ERRORS = 100;
  */
 function pushError(list, code, message) {
   if (list.length >= MAX_ERRORS) return true;
-  list.push({ code, message: `${code}: ${message}` });
+  list.push(formatItem(code, message));
   return list.length >= MAX_ERRORS;
 }
 
@@ -30,7 +39,7 @@ function pushError(list, code, message) {
  * @param {string} message
  */
 function pushWarning(list, code, message) {
-  list.push({ code, message: `${code}: ${message}` });
+  list.push(formatItem(code, message));
 }
 
 /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,8 +1,8 @@
 /**
  * viewer.js — three.js シーン・描画・PNG出力
  *
- * LineSegments2 + LineMaterial で太線を描画
- * 未変形線: 0x888888 (グレー, 2px)、変形線: 0xff4444 (赤, 3px)
+ * LineSegments2 + LineMaterial で太線を描画。
+ * 色・線幅の既定値はテーマ別に constants.js の THEME / LINE_WIDTH で定義する。
  */
 
 import * as THREE from 'three';
@@ -11,6 +11,8 @@ import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
 import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
 import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+import { THEME, LINE_WIDTH, VIEW } from './constants.js';
+import { computeFloorMetrics, toThree, setThreePosition } from './geometry.js';
 
 export class FloorViewer {
   /**
@@ -22,7 +24,7 @@ export class FloorViewer {
     // レンダラー
     this._renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
     this._renderer.setPixelRatio(window.devicePixelRatio);
-    this._renderer.setClearColor(0xffffff, 1);
+    this._renderer.setClearColor(THEME.light.clear, 1);
     this._renderer.setSize(canvasContainer.clientWidth, canvasContainer.clientHeight);
     canvasContainer.appendChild(this._renderer.domElement);
 
@@ -40,7 +42,9 @@ export class FloorViewer {
 
     // カメラ (PerspectiveCamera)
     const aspect = canvasContainer.clientWidth / canvasContainer.clientHeight || 1;
-    this._camera = new THREE.PerspectiveCamera(50, aspect, 0.1, 10000);
+    this._camera = new THREE.PerspectiveCamera(
+      VIEW.CAMERA_FOV, aspect, VIEW.CAMERA_NEAR, VIEW.CAMERA_FAR,
+    );
     this._camera.position.set(10, 10, 10);
     this._camera.lookAt(0, 0, 0);
 
@@ -98,27 +102,11 @@ export class FloorViewer {
     this._floorData = floorData;
     const { nodes, lines } = floorData;
 
-    // L_floor 算出
-    let minX = Infinity, maxX = -Infinity;
-    let minY = Infinity, maxY = -Infinity;
-    let minZ = Infinity, maxZ = -Infinity;
-    for (const node of nodes.values()) {
-      if (node.x < minX) minX = node.x;
-      if (node.x > maxX) maxX = node.x;
-      if (node.y < minY) minY = node.y;
-      if (node.y > maxY) maxY = node.y;
-      if (node.z < minZ) minZ = node.z;
-      if (node.z > maxZ) maxZ = node.z;
-    }
-    const rangeX = maxX - minX;
-    const rangeY = maxY - minY;
-    this._lFloor = Math.max(rangeX, rangeY);
-    if (this._lFloor === 0) this._lFloor = 1; // ゼロ除算回避
+    // L_floor・中心座標を算出（geometry.js に一元化）
+    const { centerX, centerY, centerZ, lFloor } = computeFloorMetrics(nodes);
+    this._lFloor = lFloor;
 
-    // 中心座標を計算
-    const centerX = (minX + maxX) / 2;
-    const centerY = (minY + maxY) / 2;
-    const centerZ = (minZ + maxZ) / 2;
+    const theme = this._theme();
 
     // --- 既存のシーン内容をクリア ---
     this._clearGroup(this._undeformedGroup);
@@ -128,7 +116,7 @@ export class FloorViewer {
     this._clearGroup(this._labelsGroup);
 
     // テーマに合わせてクリアカラーを設定
-    this._renderer.setClearColor(this._isDark ? 0x1a1a2e : 0xffffff, 1);
+    this._renderer.setClearColor(theme.clear, 1);
 
     // 解像度（LineMaterial に必要）
     const resolution = new THREE.Vector2(
@@ -136,32 +124,29 @@ export class FloorViewer {
       this._container.clientHeight
     );
 
-    // --- 未変形線 (グレー 0x888888, 2px) ---
-    // 座標マッピング: data(x,y,z) → three.js(y, z, x)
-    //   data.y → three.x (X軸: Node1→4方向)
-    //   data.z → three.y (鉛直方向 = three.js の上方向)
-    //   data.x → three.z (Y軸: Node1→2方向)
+    // --- 未変形線 ---
+    // 座標マッピングは geometry.toThree() に一元化（data → three.js）
     const undeformedPositions = [];
     for (const line of lines) {
       const ni = nodes.get(line.nodeI);
       const nj = nodes.get(line.nodeJ);
       if (!ni || !nj) continue;
-      undeformedPositions.push(ni.y, ni.z, ni.x);
-      undeformedPositions.push(nj.y, nj.z, nj.x);
+      undeformedPositions.push(...toThree(ni.x, ni.y, ni.z));
+      undeformedPositions.push(...toThree(nj.x, nj.y, nj.z));
     }
 
     const undeformedGeo = new LineSegmentsGeometry();
     undeformedGeo.setPositions(undeformedPositions);
     this._undeformedMaterial = new LineMaterial({
-      color: this._isDark ? 0xaaaaaa : 0x888888,
-      linewidth: 2,
+      color: theme.undeformed,
+      linewidth: LINE_WIDTH.undeformed,
       resolution: resolution,
     });
     const undeformedLines = new LineSegments2(undeformedGeo, this._undeformedMaterial);
     undeformedLines.computeLineDistances();
     this._undeformedGroup.add(undeformedLines);
 
-    // --- 変形線 (赤 0xff4444, 3px) ---
+    // --- 変形線 ---
     const deformedPositions = [];
     this._deformedVertexMap = [];
     let segmentIndex = 0;
@@ -172,8 +157,8 @@ export class FloorViewer {
       if (!ni || !nj) continue;
 
       // 初期状態は未変形と同じ座標 (座標マッピング適用)
-      deformedPositions.push(ni.y, ni.z, ni.x);
-      deformedPositions.push(nj.y, nj.z, nj.x);
+      deformedPositions.push(...toThree(ni.x, ni.y, ni.z));
+      deformedPositions.push(...toThree(nj.x, nj.y, nj.z));
 
       this._deformedVertexMap.push({
         nodeI: line.nodeI,
@@ -186,8 +171,8 @@ export class FloorViewer {
     this._deformedGeometry = new LineSegmentsGeometry();
     this._deformedGeometry.setPositions(deformedPositions);
     this._deformedMaterial = new LineMaterial({
-      color: this._isDark ? 0xff6666 : 0xff4444,
-      linewidth: 3,
+      color: theme.deformed,
+      linewidth: LINE_WIDTH.deformed,
       resolution: resolution,
     });
     const deformedLines = new LineSegments2(this._deformedGeometry, this._deformedMaterial);
@@ -198,25 +183,25 @@ export class FloorViewer {
     this._applyUserLineStyle();
 
     // --- AxesHelper ---
-    const axesSize = this._lFloor * 0.5;
-    const axes = new THREE.AxesHelper(axesSize);
+    const axes = new THREE.AxesHelper(this._lFloor * VIEW.AXES_SIZE_FACTOR);
     this._axesGroup.add(axes);
 
     // --- GridHelper ---
-    const gridSize = this._lFloor * 1.5;
-    const gridDivisions = 10;
-    const gridColor = this._isDark ? 0x444466 : 0xcccccc;
-    const grid = new THREE.GridHelper(gridSize, gridDivisions, gridColor, gridColor);
+    const gridSize = this._lFloor * VIEW.GRID_SIZE_FACTOR;
+    const grid = new THREE.GridHelper(gridSize, VIEW.GRID_DIVISIONS, theme.grid, theme.grid);
     // GridHelper は XZ 平面に作成されるため、中心をフロアに合わせる
-    grid.position.set(centerY, centerZ, centerX);
+    setThreePosition(grid, centerX, centerY, centerZ);
     this._gridGroup.add(grid);
 
     // --- カメラ位置調整 ---
     // 原点(軸)がビューポート左下に来るよう配置
     // 左寄り(大きな-X offset)・少し手前(-Z offset)のアングルで
     // 時計回り(1→4→3→2)の配置となる
-    const dist = this._lFloor * 1.5;
-    this._camera.position.set(centerY - dist * 0.85, centerZ + dist * 0.7, centerX + dist * 0.4);
+    const dist = this._lFloor * VIEW.CAMERA_DIST_FACTOR;
+    const off = VIEW.CAMERA_OFFSET;
+    this._camera.position.set(
+      centerY + dist * off.x, centerZ + dist * off.y, centerX + dist * off.z,
+    );
     this._controls.target.set(centerY, centerZ, centerX);
     this._controls.update();
 
@@ -226,9 +211,14 @@ export class FloorViewer {
       labelDiv.className = 'node-label';
       labelDiv.textContent = node.id;
       const labelObj = new CSS2DObject(labelDiv);
-      labelObj.position.set(node.y, node.z, node.x);
+      setThreePosition(labelObj, node.x, node.y, node.z);
       this._labelsGroup.add(labelObj);
     }
+  }
+
+  /** 現在のテーマ色セットを返す */
+  _theme() {
+    return this._isDark ? THEME.dark : THEME.light;
   }
 
   /**
@@ -252,9 +242,9 @@ export class FloorViewer {
       const zI = getDisplacedZ(entry.nodeI);
       const zJ = getDisplacedZ(entry.nodeJ);
 
-      // three.js 座標系: x=y, y=z(上), z=x
-      startAttr.setXYZ(entry.segmentIndex, ni.y, zI, ni.x);
-      endAttr.setXYZ(entry.segmentIndex, nj.y, zJ, nj.x);
+      // 変位後の z を使って data → three.js 座標へマッピング
+      startAttr.setXYZ(entry.segmentIndex, ...toThree(ni.x, ni.y, zI));
+      endAttr.setXYZ(entry.segmentIndex, ...toThree(nj.x, nj.y, zJ));
     }
 
     // instanceStart と instanceEnd は同じ InstancedInterleavedBuffer を共有
@@ -264,7 +254,7 @@ export class FloorViewer {
 
   /**
    * 各要素の表示ON/OFF切替
-   * @param {Object} visibility - { undeformed, deformed, axes, grid }
+   * @param {Object} visibility - { undeformed, deformed, axes, grid, labels }
    */
   setVisibility({ undeformed, deformed, axes, grid, labels }) {
     if (undeformed !== undefined) this._undeformedGroup.visible = !!undeformed;
@@ -280,7 +270,7 @@ export class FloorViewer {
    * @returns {Promise<void>}
    */
   savePNG(filename) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       // 最新の描画を保証
       this._renderer.render(this._scene, this._camera);
 
@@ -289,9 +279,15 @@ export class FloorViewer {
       link.href = dataURL;
       link.download = filename || 'floor_mode.png';
       document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      resolve();
+      try {
+        link.click();
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        // 例外時も <a> を確実に除去する
+        document.body.removeChild(link);
+      }
     });
   }
 
@@ -414,21 +410,23 @@ export class FloorViewer {
 
     if (!this._renderer) return;
 
+    const theme = this._theme();
+
     // Renderer clear color
-    this._renderer.setClearColor(isDark ? 0x1a1a2e : 0xffffff, 1);
+    this._renderer.setClearColor(theme.clear, 1);
 
     // Undeformed lines: ユーザー指定がない場合のみテーマデフォルトを適用
     if (this._undeformedMaterial && this._userLineStyle.undeformedColor === null) {
-      this._undeformedMaterial.color.setHex(isDark ? 0xaaaaaa : 0x888888);
+      this._undeformedMaterial.color.setHex(theme.undeformed);
     }
 
     // Deformed lines: ユーザー指定がない場合のみテーマデフォルトを適用
     if (this._deformedMaterial && this._userLineStyle.deformedColor === null) {
-      this._deformedMaterial.color.setHex(isDark ? 0xff6666 : 0xff4444);
+      this._deformedMaterial.color.setHex(theme.deformed);
     }
 
     // Grid: ダーク時は控えめに抑えて線を邪魔しない
-    const gridColor = isDark ? 0x444466 : 0xcccccc;
+    const gridColor = theme.grid;
     this._gridGroup.traverse((child) => {
       if (child.isLineSegments && child.material) {
         if (Array.isArray(child.material)) {
@@ -467,6 +465,11 @@ export class FloorViewer {
         } else {
           child.material.dispose();
         }
+      }
+      // CSS2DObject はオーバーレイ DOM に <div> を挿入するため、
+      // シーンから外すだけでなく DOM 要素も明示的に破棄する（再読込時のリーク防止）
+      if (child instanceof CSS2DObject && child.element) {
+        child.element.remove();
       }
     }
   }


### PR DESCRIPTION
## 概要
複数のサブエージェントによる多角的レビュー（**DRY/重複**・**バグ/正当性**・**アーキテクチャ/可読性**）の結果をもとに、`CLAUDE.md` のモジュール間インターフェース規約（`AnimationController` / `FloorViewer` / `parseFloorData` / `validateFloorData` の公開シグネチャ）を**一切変更せず**に内部実装を整理しました。

## 新規モジュール
- **`src/constants.js`** — テーマ色 / 線幅 / 範囲(`SCALE`,`SPEED`) / `EPS` / `TWO_PI` / localStorage キー / `DOM_IDS` / ビュー係数（カメラ・グリッド・軸）を一元管理
- **`src/geometry.js`** — `computeFloorMetrics()`（L_floor / A_ref / 中心算出）と `toThree()` / `setThreePosition()`（data→three.js 座標マッピング）

## 重複解消（DRY）
- `L_floor` 計算の二重実装（`animation.js` / `viewer.js`）を `geometry.js` に集約
- 座標マッピング（旧 6 箇所にインライン展開）を `toThree` / `setThreePosition` に統一 — 過去に座標系修正コミットが複数入っていた箇所の単一ソース化
- テーマ色の「マテリアル生成時」「テーマ切替時」の二重定義を `THEME` 定数に一本化（片側更新漏れによる色不整合を防止）
- `validator` のメッセージ整形（`E_XXX_YYY:`）を `formatItem` に集約
- 長大だった `setupUI`（約 236 行）を責務別のセクション関数に分割し、スライダー配線を `wireSlider` ヘルパーに共通化

## バグ / 堅牢性修正
| 深刻度 | 内容 |
|---|---|
| 高 | `viewer`: ノードラベル `CSS2DObject` の DOM 要素破棄漏れ（別ファイル再読込で `<div>` が累積するリーク）を `_clearGroup` で修正 |
| 中 | `ui`: 再生中にモード切替すると停止状態になるのに `applyVisibility` が呼ばれず、節点番号ラベルが非表示のまま残る不整合を修正 |
| 中 | `app`: サンプル JSON がバリデーション失敗した場合に描画ループが起動せず画面が固まる問題を修正（必ずループ起動） |
| 低 | `viewer.savePNG`: `try/finally` で `<a>` 除去を保証し `reject` を配線 |
| 低 | `i18n`: `replaceAll` でリテラル置換し、置換値の `$&` 等の特殊パターン展開を回避 |
| 低 | `app`: `#error-container` の null ガード追加 / `animation`: `freqHz` 取得を `?? 0` に変更 |

## 検証
- ✅ `npx eslint src/` — クリーン
- ✅ `npm run build` — 19 modules 変換成功
- ✅ 全座標マッピング呼び出しが旧実装と同一出力になることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)